### PR TITLE
add long description and classifiers to setup.py [DNS-1294]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,38 @@ install_requires = [
     "mock",
 ]
 
+from os import path
+
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, "README.md")) as f:
+    long_description = f.read()
 
 setup(
     name="certbot-dns-ionos",
     version="0.1.0",
     description="Certbot DNS Authenticator plugin for IONOS",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/ionos-cloud/certbot-dns-ionos-cloud",
     author="IONOS Cloud DNS team",
     author_email="paas-dns@ionos.com",
     license="Apache License 2.0",
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    classifiers=[],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Plugins",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Topic :: Internet :: Name Service (DNS)",
+        "Topic :: Security",
+        "Topic :: Security :: Cryptography",
+        "Topic :: System :: Networking",
+        "Topic :: System :: Systems Administration",
+        "Topic :: Utilities",
+    ],
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,


### PR DESCRIPTION
it's required to have the long_description (which is used to render the PyPi page) field in the setup.py, otherwise the release fails: https://github.com/ionos-cloud/certbot-dns-ionos-cloud/actions/runs/8689350456/job/23826862758

Additionally, I have added some classifiers in the setup.py. As mentionned in the documentation: https://pypi.org/classifiers/, the classifiers are used to find the projects when searching in pypi. Classifiers can only be chosen from the predefined list defined in https://pypi.org/classifiers/